### PR TITLE
fix: include path for headers

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -71,7 +71,7 @@ class LibmodbusConan(ConanFile):
                 self.cpp_info.libs[0] += '_d'
         else:
             self.cpp_info.libs = ["modbus"]
-        self.cpp_info.includedirs =["include/modbus"]
+        self.cpp_info.includedirs = ["include"]
 
     def configure(self):
         del self.settings.compiler.libcxx

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -1,7 +1,7 @@
 #include <cstdlib>
 #include <iostream>
 
-#include "modbus.h"
+#include "modbus/modbus.h"
 
 int main() {
   


### PR DESCRIPTION
by default the install location for the headers upstream is under linux `/usr/local/include/modbus/modbus.h`


currently the conan recipe is exporting the include path `$package/uuid/include/modbus` instead of `$package/uuid/include` -> users cannot include `#include "modbus/modbus.h` but have to use `#include "modbus.h"`

this patch exports the headers to paths as upstream does