### PR TITLE
modify '--host' for linux x86 cross build with Shared=True

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -48,7 +48,7 @@ class LibmodbusConan(ConanFile):
 
             # Assumes that x86 is the host os and building for e.g. armv7
             if self.settings.arch != "x86_64" or self.settings.arch != "x86":
-                cross_host = "--host={arch}-none-{os} ".format(arch = self.settings.arch, os = self.settings.os.lower())
+                cross_host = "--host={arch}-none-{os} ".format(arch = self.settings.arch, os = str(self.settings.os).lower())
             else:
                 cross_host = ""
             env_build = AutoToolsBuildEnvironment(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -48,7 +48,7 @@ class LibmodbusConan(ConanFile):
 
             # Assumes that x86 is the host os and building for e.g. armv7
             if self.settings.arch != "x86_64" or self.settings.arch != "x86":
-                cross_host = "--host={} ".format(self.settings.arch)
+                cross_host = "--host={arch}-none-{os} ".format(arch = self.settings.arch, os = self.settings.os)
             else:
                 cross_host = ""
             env_build = AutoToolsBuildEnvironment(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -48,7 +48,7 @@ class LibmodbusConan(ConanFile):
 
             # Assumes that x86 is the host os and building for e.g. armv7
             if self.settings.arch != "x86_64" or self.settings.arch != "x86":
-                cross_host = "--host={arch}-none-{os} ".format(arch = self.settings.arch, os = self.settings.os)
+                cross_host = "--host={arch}-none-{os} ".format(arch = self.settings.arch, os = self.settings.os.lower())
             else:
                 cross_host = ""
             env_build = AutoToolsBuildEnvironment(self)


### PR DESCRIPTION
I was trying to (cross-)compile shared libraries for linux, but could not find the .so files.
I am using a vagrant Centos7 machine with gcc 4.8.5 and libtool 2.4.2 and compile for x86 with compiler options '-m32'
I am explicitly setting the arch option to 'x86' which results in a configure line
`./configure --host=x86 --enable-host-shared --prefix /home/vagrant/.conan/data/libmodbus/3.1.6/joakimono/stable/package/c4e5ad81b2b85467f6f38120e09a7a00b25c6705`

In the config.log, one can read:

> checking whether stripping libraries is possible... yes
> checking if libtool supports shared libraries... no
> checking whether to build shared libraries... no
It turns out, that libtool does not understand 'x86' as host, but needs a full gnu system name e.g.: "x86-none-linux'
Additionally, it seems, that '--enable-host-shared' is not supported by libmodbus' configure script
> configure: WARNING: unrecognized options: --enable-host-shared
This pull request does address this, though.

I am not sure what a good way would be to modify the travis integration to check, if static or shared objects were generated, 